### PR TITLE
Fixed error handling in register mutation

### DIFF
--- a/server/src/resolvers/user.ts
+++ b/server/src/resolvers/user.ts
@@ -175,6 +175,16 @@ export class UserResolver {
       //|| err.detail.includes("already exists")) {
       // duplicate username error
       if (err.code === "23505") {
+        if (err.detail.includes("email")){
+          return {
+            errors: [
+              {
+                field: "email",
+                message: "email already taken",
+              },
+            ],
+          };
+        }
         return {
           errors: [
             {


### PR DESCRIPTION
Before fix: If you try to enter an email that has already been used, the error will still be treated as "username already exists", because both email and username field throws 23505 error code.